### PR TITLE
Minor Fixes on Overflow Issues

### DIFF
--- a/components/EmailCopyable.tsx
+++ b/components/EmailCopyable.tsx
@@ -21,7 +21,7 @@ export function CopyEmail({ email }: { email: string }) {
         <TooltipTrigger asChild>
           <span
             onClick={handleCopy}
-            className="cursor-copy w-fit font-quantico font-bold text-foreground lg:text-xl text-base tracking-[0] leading-[normal] hover:text-title" 
+            className="cursor-copy w-fit font-quantico font-bold text-foreground lg:text-xl sm:text-base text-sm tracking-[0] leading-[normal] hover:text-title custom-scrollbar" 
           >
             {email}
           </span>

--- a/sections/Hero.tsx
+++ b/sections/Hero.tsx
@@ -30,7 +30,7 @@ export default function Hero() {
         </div>
 
         <div className="inline-flex md:py-2 items-center gap-2.5">
-          <h2 className="relative w-fit font-extrabold text-foreground lg:text-5xl md:text-[42px] text-[28px] tracking-[0] md:leading-[40px] leading-normal">
+          <h2 className="relative w-fit font-extrabold text-foreground lg:text-5xl md:text-[42px] text-[28px] tracking-[0] md:leading-[40px] sm:text-left text-center xs:leading-normal leading-6">
             Full Stack Developer
           </h2>
         </div>

--- a/sections/Navbar.tsx
+++ b/sections/Navbar.tsx
@@ -56,7 +56,7 @@ export default function Navbar() {
 
   return (
     <header className="flex w-full h-fit items-center md:justify-between gap-2.5 lg:px-[25px] md:px-3 pl-[25px] pr-3 lg:py-2.5 md:py-1.5 py-2.5 bg-background border-b border-primary-outline sticky top-0 z-20">
-      <div className="inline-flex md:w-fit w-full items-center justify-center lg:pl-5 lg:pr-2.5 md:pl-3 md:pr-1 pl-5 pr-2.5 py-2.5">
+      <div className="inline-flex md:w-fit w-full items-center justify-center lg:pl-5 lg:pr-2.5 md:pl-3 md:pr-1 xs:pl-5 xs:pr-2.5 pl-2 pr-0.5 py-2.5 overflow-x-auto">
         <CopyEmail email={"garryworkwithit@gmail.com"} />
       </div>
 


### PR DESCRIPTION
Fixes of Overflowing on Smaller Screens:

1. Overflowing of Navbar and cause the entire document to expand.
2. Text Alignment of Role in Hero Section Fix.